### PR TITLE
Replacing pycurl2 with pycurl (refs #25721)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,8 @@ Changelog
 
 1.7-dev - (unreleased)
 ----------------------
+* Change: Use pycurl instead of pycurl2 (unmaintained)
+  [david-batranu refs #25721]
 
 1.6 - (2014-09-15)
 ------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,16 +1,16 @@
 Installing `sparql-client`
 ==========================
 
-The `sparql-client` library is available from PyPI and has dependency on pycurl2,
+The `sparql-client` library is available from PyPI and has dependency on pycurl,
 which also depends on libcurl
 In order to install sparql-client first you have to install libcurl >= 7.19.0, or you can
 build it from the sources following the instructions from
 
     http://curl.haxx.se/docs/install.html
 
-The next step is to install pycurl2:
+The next step is to install pycurl:
 
-    pip install pycurl2
+    pip install pycurl
 
 The last step is to install sparql-client:
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name=NAME,
       url='http://www.eionet.europa.eu/software/sparql-client',
       py_modules =['sparql'],
       install_requires=[
-          'pycurl2',
+          'pycurl',
       ],
 
       )

--- a/sparql.py
+++ b/sparql.py
@@ -57,7 +57,7 @@ import os.path
 import re
 import tempfile
 
-import pycurl2 as pycurl
+import pycurl
 import StringIO
 __version__ = '0.17-dev'
 

--- a/tests/testhttp.py
+++ b/tests/testhttp.py
@@ -1,6 +1,6 @@
 import unittest
 #import urllib2
-import pycurl2 as pycurl
+import pycurl
 from StringIO import StringIO
 from mock import Mock, patch
 import sparql


### PR DESCRIPTION
pycurl2 is no longer maintained and the installation is very difficult.