### PR TITLE
Fixing incompatibilities with Python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ searchindex.js
 search.html
 pylint.log
 pyflakes.log
+.idea/
+venv/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+
 try:
     from setuptools import setup
 except ImportError:
@@ -7,17 +8,17 @@ except ImportError:
 NAME = 'sparql-client'
 VERSION = open('version.txt').read().strip()
 
-
 setup(name=NAME,
       version=VERSION,
       description='Python API to query a SPARQL endpoint',
-      long_description=open('README.rst').read() + "\n\n" + \
-                       open(os.path.join("docs", "HISTORY.txt")).read(),
+      long_description=open('README.rst').read() + "\n\n"
+      + open(os.path.join("docs", "HISTORY.txt")).read(),
       classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 2.7",
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries :: Python Modules',
@@ -37,6 +38,7 @@ setup(name=NAME,
       extras_require={
             'test': [
                 'mock',
+                'python-dateutil',
             ]
       },
 

--- a/sparql-client/tests/testn3parse.py
+++ b/sparql-client/tests/testn3parse.py
@@ -1,6 +1,8 @@
 import unittest
-import sparql
+
 import six
+
+import sparql
 
 try:
     from testdatatypes import _literal_data
@@ -8,15 +10,15 @@ except ImportError:
     from .testdatatypes import _literal_data
 
 _string_literals = [
-    ('""', ''), # empty string
-    ("''", ''), # empty string
-    ('""""""', ''), # triple quotes (")
-    ("''''''", ''), # triple quotes (')
-    ('" "', ' '), # one space
+    ('""', ''),  # empty string
+    ("''", ''),  # empty string
+    ('""""""', ''),  # triple quotes (")
+    ("''''''", ''),  # triple quotes (')
+    ('" "', ' '),  # one space
     ('"hi"', 'hi'),
     ("'hi'", 'hi'),
-    ("'some\\ntext'", 'some\ntext'), # newline
-    ("'some\\ttext'", 'some\ttext'), # tab
+    ("'some\\ntext'", 'some\ntext'),  # newline
+    ("'some\\ttext'", 'some\ttext'),  # tab
     ("'''some\ntext\n   with spaces'''", 'some\ntext\n   with spaces'),
 ]
 

--- a/sparql.py
+++ b/sparql.py
@@ -47,7 +47,9 @@ and then executes them. Use a double line (two 'enters') to separate queries.
 Otherwise, the query is read from standard input.
 """
 
-from base64 import encodestring
+from base64 import encodebytes
+from typing import cast
+
 from six.moves import input, map
 from six.moves.urllib.parse import urlencode
 from xml.dom import pulldom
@@ -70,7 +72,9 @@ try:
 except Exception:
     __version__ = "2.6"
 
-USER_AGENT = "sparql-client/%s +https://www.eionet.europa.eu/software/sparql-client/" % __version__
+USER_AGENT = \
+    "sparql-client/%s +https://www.eionet.europa.eu/software/sparql-client/" \
+    % __version__
 
 CONTENT_TYPE = {
                  'turtle': "application/turtle",
@@ -313,21 +317,13 @@ def parse_n3_term(src):
                 raise ValueError
             value = value_node.value
         else:
-            # Don't allow any extra tokens in the AST
-            if len(ast.body) != 1:
+            if len(ast.body) != 1 \
+                    or not isinstance(ast.body[0], astcompiler.Assign):
                 raise ValueError
-            assign_node = ast.body[0]
-
-            if len(assign_node._fields) != 2:
+            assign_node = cast(astcompiler.Assign, ast.body[0])
+            if not isinstance(assign_node.value, astcompiler.Constant):
                 raise ValueError
-
-            value_node = assign_node.value
-            if len(value_node._fields) != 1:
-                raise ValueError
-
-            # if value_node.__class__ != ast.Constant():
-            #     raise ValueError
-            value = getattr(value_node, value_node._fields[0])
+            value = cast(astcompiler.Constant, assign_node.value).value
 
         if type(value) is not six.text_type:
             raise ValueError
@@ -417,8 +413,10 @@ class Service(_ServiceMixin):
 
     def authenticate(self, username, password):
         # self._headers_map['Authorization'] = "Basic %s" % replace(
-        #         encodestring("%s:%s" % (username, password)), "\012", "")
-        head = "Basic %s" % encodestring("%s:%s" % (username, password)).replace("\012", "")
+        #         encodebytes("%s:%s" % (username, password)), "\012", "")
+        head = "Basic %s" % encodebytes(
+            "%s:%s" % (username, password)
+        ).replace("\012", "")
         self._headers_map['Authorization'] = head
 
 
@@ -502,7 +500,7 @@ class _Query(_ServiceMixin):
                 separator = '&'
             else:
                 separator = '?'
-            uri = self.endpoint.strip() + separator + query
+            uri = self.endpoint.strip() + str(separator) + str(query)
             return ev_request.Request(uri)
         else:
             # uri = self.endpoint.strip().encode('ASCII')
@@ -579,12 +577,16 @@ class _Query(_ServiceMixin):
         Creates the REST query string from the statement and graphs.
         """
         args = []
-        # refs #72876 removing the replace of newline to allow the comments in sparql queries
+        # refs #72876 removing the replace of newline to allow the comments
+        # in sparql queries
         # statement = statement.replace("\n", " ").encode('utf-8')
         # not needed py3
         # statement = statement.encode('utf-8')
 
-        pref = ' '.join(["PREFIX %s: <%s> " % (p, self._prefix_map[p]) for p in self._prefix_map])
+        pref = ' '.join([
+            "PREFIX %s: <%s> " % (p, self._prefix_map[p])
+            for p in self._prefix_map
+        ])
         if six.PY2:
             statement = pref + statement
         else:
@@ -604,7 +606,8 @@ class _Query(_ServiceMixin):
 
 class RedirectHandler(ev_request.HTTPRedirectHandler):
     """
-    Subclass the HTTPRedirectHandler to re-contruct request when follow redirect
+    Subclass the HTTPRedirectHandler to re-contruct request
+    when follow redirect
     """
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         if code in (301, 302, 303, 307):
@@ -689,7 +692,9 @@ class _ResultsParser(object):
                     if node.tagName == 'result':
                         self._vals = [None] * len(self.variables)
                     elif node.tagName == 'binding':
-                        idx = self.variables.index(node.attributes['name'].value)
+                        idx = self.variables.index(
+                            node.attributes['name'].value
+                        )
                     elif node.tagName == 'uri':
                         self.events.expandNode(node)
                         data = ''.join(t.data for t in node.childNodes)
@@ -698,7 +703,8 @@ class _ResultsParser(object):
                         self.events.expandNode(node)
                         data = ''.join(t.data for t in node.childNodes)
                         lang = node.getAttribute('xml:lang') or None
-                        datatype = Datatype(node.getAttribute('datatype')) or None
+                        datatype = \
+                            Datatype(node.getAttribute('datatype')) or None
                         self._vals[idx] = Literal(data, datatype, lang)
                     elif node.tagName == 'bnode':
                         self.events.expandNode(node)
@@ -776,6 +782,7 @@ class SparqlException(Exception):
     def __init__(self, code, message):
         self.code = code
         self.message = message
+
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Fixes:
* The problem with removed base64.encodestring() and base64.decodestring() methods
* The problem with Python3 implementation of parse_n3_term() (the method relied on protected fields of ast library objects and their semantics changed, which meant that the ValueError would be returned on parsing strings, for example)
* Some minor issues highlighted by PEP linter (long lines, indentation)
